### PR TITLE
[CCTRI-1251] Fix error inconsistencies

### DIFF
--- a/api/client.py
+++ b/api/client.py
@@ -4,6 +4,11 @@ from flask import current_app
 
 from api.errors import UnexpectedC1fAppError
 
+NOT_CRITICAL_ERRORS = (
+    'Unsupported request ? IPv4/Domain only',  # ToDo
+    'Empty Search! Availiable search: IPv4/URL/Domain'
+)
+
 
 class C1fAppClient:
     def __init__(self, api_key):
@@ -24,7 +29,10 @@ class C1fAppClient:
             self.api_url, headers=self.headers, json=self.data
         )
 
-        if not response.ok:
-            raise UnexpectedC1fAppError(response)
+        if response.text in NOT_CRITICAL_ERRORS:
+            return []
 
-        return response.json()
+        if response.ok:
+            return response.json()
+
+        raise UnexpectedC1fAppError(response)

--- a/api/client.py
+++ b/api/client.py
@@ -5,8 +5,8 @@ from flask import current_app
 from api.errors import UnexpectedC1fAppError
 
 NOT_CRITICAL_ERRORS = (
-    'Unsupported request ? IPv4/Domain only',  # ToDo
-    'Empty Search! Availiable search: IPv4/URL/Domain'
+    'Unsupported request ? IPv4/Domain only',
+    'Empty Search! Available search: IPv4/URL/Domain'
 )
 
 

--- a/api/mappings.py
+++ b/api/mappings.py
@@ -52,7 +52,7 @@ class Mapping(metaclass=ABCMeta):
             'id': f'transient:sighting-{uuid4()}',
             'type': 'sighting',
             'source': 'C1fApp',
-            'source_uri': record['source'][0].split(',')[0],
+            'source_uri': max(record['source'][0].split(','), key=len),
             'confidence': self._map_confidence(record['confidence'][0]),
             'count': 1,
             'description': 'Seen on C1fApp feed',

--- a/api/mappings.py
+++ b/api/mappings.py
@@ -139,7 +139,7 @@ class Domain(Mapping):
             result.append(self.observable_relation(
                 'Contains',
                 {'type': 'url', 'value': address[0]},
-                record['domain'][0])
+                {'type': 'domain', 'value': record['domain'][0]})
             )
         for ip in ips:
             if ip:

--- a/api/mappings.py
+++ b/api/mappings.py
@@ -139,7 +139,7 @@ class Domain(Mapping):
             result.append(self.observable_relation(
                 'Contains',
                 {'type': 'url', 'value': address[0]},
-                self.observable)
+                record['domain'][0])
             )
         for ip in ips:
             if ip:


### PR DESCRIPTION
Unfortunately, in this integration, I can’t use the status code to determine whether the error is critical or not critical. This is because many different errors have the same code **403**. 
![Screenshot 2020-06-15 at 18 01 21](https://user-images.githubusercontent.com/48979187/84673438-5f47fb80-af32-11ea-9e7f-b5e00ccb485a.png)
![Screenshot 2020-06-15 at 18 09 07](https://user-images.githubusercontent.com/48979187/84674188-5277d780-af33-11ea-9704-589f4a8b76dd.png)
![Screenshot 2020-06-15 at 18 08 51](https://user-images.githubusercontent.com/48979187/84674309-776c4a80-af33-11ea-868d-daaa2ce520ca.png)


