### PR TITLE
[CCTRI-1326] Fix incorrectly formatted fatal error while health check

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -67,4 +67,7 @@ def jsonify_result():
     if g.get('errors'):
         result['errors'] = g.errors
 
+    if not result['data']:
+        del result['data']
+
     return jsonify(result)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -108,7 +108,6 @@ def c1fapp_response_unauthorized_creds(secret_key):
 @fixture(scope='session')
 def unauthorized_creds_body():
     return {
-        'data': {},
         'errors': [
             {'code': FORBIDDEN,
              'message': 'Unexpected response from C1fApp: Invalid API key',
@@ -155,7 +154,6 @@ def invalid_jwt(valid_jwt):
 def invalid_jwt_expected_payload(route):
     if route in ('/observe/observables', '/health'):
         return {
-            'data': {},
             'errors': [
                 {'code': PERMISSION_DENIED,
                  'message': 'Invalid Authorization Bearer JWT.',
@@ -174,15 +172,15 @@ def invalid_jwt_expected_payload(route):
 def invalid_json_expected_payload(route, client):
     if route.endswith('/observe/observables'):
         return {
-            'data': {},
             'errors':
                 [
-                {'code': INVALID_ARGUMENT,
-                 'message':
-                     "Invalid JSON payload received. "
-                     "{0: {'value': ['Missing data for required field.']}}",
-                 'type': 'fatal'}
-            ]
+                    {'code': INVALID_ARGUMENT,
+                     'message':
+                         "Invalid JSON payload received. "
+                         "{0: {'value': ['Missing data for "
+                         "required field.']}}",
+                     'type': 'fatal'}
+                ]
         }
 
     if route.endswith('/deliberate/observables'):


### PR DESCRIPTION
In a situation when the health endpoint receives empty dict "data" and an error, such a problem occurs:
![image](https://user-images.githubusercontent.com/48979187/85856512-d1390400-b7c0-11ea-9590-173cb247bede.png)
That's  because TR extracts "status" key, but it is missing in this case.